### PR TITLE
feat: Append trailing slash to directory result

### DIFF
--- a/zfzf.zsh
+++ b/zfzf.zsh
@@ -366,6 +366,10 @@ EOF
     path_new="$input"
   fi
 
+  if [[ -d "${path_new}" ]]; then
+    path_new="${path_new}/"
+  fi
+
   if [[ "$mode" == "zle" ]]; then
     LBUFFER="${left}${path_new}"
     RBUFFER="$right"


### PR DESCRIPTION
Thank you for the nice `zsh` plugin. 
Very useful so far, but I really wanted that feature :) 

As I am not really familiar with the code yet, I hope this is the correct place, where the slash is added.